### PR TITLE
Add required fiware-service header

### DIFF
--- a/FIWARE/module.php
+++ b/FIWARE/module.php
@@ -104,7 +104,9 @@
 					'method'  => 'PUT',
 					'header'  => "X-Auth-Token: $token\r\n".
 								 "Content-Type: application/json\r\n".
-								 'Content-Length:'. strlen($json) . "\r\n",
+								 'Content-Length:'. strlen($json) . "\r\n".
+					                         'fiware-service:':'inspire'. "\r\n",      
+
 					'content' => $json
 				]
 			];
@@ -155,7 +157,8 @@
 					'method'  => 'POST',
 					'header'  => "X-Auth-Token: $token\r\n".
 								 "Content-Type: application/json\r\n".
-								 'Content-Length:'. strlen($json) . "\r\n",
+								 'Content-Length:'. strlen($json) . "\r\n".
+					                         'fiware-service:':'inspire'. "\r\n",      
 					'content' => $json
 				]
 			];

--- a/FIWARE/module.php
+++ b/FIWARE/module.php
@@ -76,7 +76,7 @@
 
 			$data = [
 				"name" => [
-					"value" => IPS_GetName($VariableID)
+					"value" => "urn:ngsi-ld:TemperatureObserved:" . IPS_GetName($VariableID)
 				],
 				"location" => [
 					"type" => "geo:json",
@@ -129,7 +129,7 @@
 				"type" => "TemperatureObserved",
 				"id" => "Sensor_$VariableID",
 				"name" => [
-					"value" => IPS_GetName($VariableID)
+					"value" => "urn:ngsi-ld:TemperatureObserved:" . IPS_GetName($VariableID)
 				],
 				"location" => [
 					"type" => "geo:json",


### PR DESCRIPTION
The history module (STH comet) of FIWARE requires the header to work correctly. It has to be present when inserting data into orion
Should probably be made configurable.